### PR TITLE
feature: Broaden out_selectors to allow emitting any v3 message

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -37,9 +37,10 @@ class AgentInjectAsset(agent.Agent):
     def _legacy_emit_assets(self):
         """Asset injection as done by Ostorlab version 0.3.1 and before."""
         try:
-            with open(ASSET_RAW_PATH, "rb") as asset_raw_o, open(
-                ASSET_SELECTOR_PATH, "r", encoding="utf-8"
-            ) as asset_selector_o:
+            with (
+                open(ASSET_RAW_PATH, "rb") as asset_raw_o,
+                open(ASSET_SELECTOR_PATH, "r", encoding="utf-8") as asset_selector_o,
+            ):
                 asset = asset_raw_o.read()
                 selector = asset_selector_o.read()
                 logger.info(
@@ -56,9 +57,12 @@ class AgentInjectAsset(agent.Agent):
             for raw_asset_path in glob.glob(f"{ASSET_DIR}{RAW_PATTERN}*"):
                 asset_id = raw_asset_path.split("_", 1)[1]
                 asset_selector_path = f"{SELECTOR_PATTERN}{asset_id}"
-                with open(raw_asset_path, "rb") as asset_raw_o, open(
-                    asset_selector_path, "r", encoding="utf-8"
-                ) as asset_selector_o:
+                with (
+                    open(raw_asset_path, "rb") as asset_raw_o,
+                    open(
+                        asset_selector_path, "r", encoding="utf-8"
+                    ) as asset_selector_o,
+                ):
                     asset = asset_raw_o.read()
                     selector = asset_selector_o.read()
                     logger.info(

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -26,20 +26,7 @@ license: Apache-2.0
 source: https://github.com/Ostorlab/agent_inject_asset
 in_selectors: [] # Has no input assets, implements start method only.
 out_selectors:
-  - v3.asset.file.android.aab
-  - v3.asset.file.android.apk
-  - v3.asset.dns.a_record
-  - v3.asset.file
-  - v3.asset.file.ios.ipa
-  - v3.asset.ip.v4
-  - v3.asset.ip.v6
-  - v3.asset.domain_name
-  - v3.asset.agent
-  - v3.asset.link
-  - v3.asset.store.android_store
-  - v3.asset.store.ios_store
-  - v3.asset.store.ios_testflight
-  - v3.asset.file.api_schema
+  - v3
 docker_file_path : Dockerfile # Dockerfile path for automated release build.
 docker_build_root : . # Docker build dir for automated release build.
 supported_architectures:


### PR DESCRIPTION
## Summary

- Change `out_selectors` from an explicit asset list to a `v3` prefix, allowing the agent to emit any `v3` message (e.g., `v3.report.risk`)
- Required for the new risk CLI flow where `inject_asset` emits `v3.report.risk` onto the message bus