### PR TITLE
fix: replace pip with uv in agent Dockerfile for faster dependency resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN pip install uv
 RUN mkdir /install
 WORKDIR /install
 COPY requirement.txt /requirement.txt
-RUN uv pip install --prefix=/install --system -r /requirement.txt
+RUN uv pip install --prefix=/install -r /requirement.txt
 FROM base
 COPY --from=builder /install /usr/local
 RUN mkdir -p /app/agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.11-slim as base
 FROM base as builder
+RUN pip install uv
 RUN mkdir /install
 WORKDIR /install
 COPY requirement.txt /requirement.txt
-RUN pip install --prefix=/install -r /requirement.txt
+RUN uv pip install --prefix=/install --system -r /requirement.txt
 FROM base
 COPY --from=builder /install /usr/local
 RUN mkdir -p /app/agent


### PR DESCRIPTION
Replaces `pip` with `uv` in the agent builder stage to fix dependency resolution failures caused by pip's ResolutionTooDeep error when resolving ostorlab[agent]'s transitive dependency conflicts.