### PR TITLE
feat: add pluggable repository providers for shared-volume checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ WORKDIR /install
 COPY requirement.txt /requirement.txt
 RUN pip install --prefix=/install -r /requirement.txt
 FROM base
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /install /usr/local
 RUN mkdir -p /app/agent
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
+ENV PYTHONPATH=/app
 WORKDIR /app/agent
 CMD ["python3.11", "/app/agent/agent.py"]

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,15 +1,22 @@
-"""Sample agent implementation"""
+"""Inject asset agent."""
 
 import glob
 import logging
 import pathlib
 
 from ostorlab.agent import agent
+from ostorlab.agent.message import message as agent_message
 from rich import logging as rich_logging
+
+from providers import base
+from providers import errors as provider_errors
+from providers import registry
 
 ASSET_DIR = "/asset/"
 RAW_PATTERN = "asset.binproto_"
 SELECTOR_PATTERN = "/asset/selector.txt_"
+REPOSITORY_SELECTOR = "v3.asset.repository"
+SHARED_VOLUME_DIR = "/code"
 
 # Before Ostorlab version 0.3.1 (including).
 ASSET_RAW_PATH = "/tmp/asset.binproto"
@@ -34,42 +41,70 @@ class AgentInjectAsset(agent.Agent):
         else:
             self._emit_assets()
 
-    def _legacy_emit_assets(self):
+    def _legacy_emit_assets(self) -> None:
         """Asset injection as done by Ostorlab version 0.3.1 and before."""
         try:
-            with open(ASSET_RAW_PATH, "rb") as asset_raw_o, open(
-                ASSET_SELECTOR_PATH, "r", encoding="utf-8"
-            ) as asset_selector_o:
+            with (
+                open(ASSET_RAW_PATH, "rb") as asset_raw_o,
+                open(ASSET_SELECTOR_PATH, "r", encoding="utf-8") as asset_selector_o,
+            ):
                 asset = asset_raw_o.read()
                 selector = asset_selector_o.read()
-                logger.info(
-                    "injecting asset of size %d to selector %s", len(asset), selector
-                )
-                self.emit_raw(selector=selector, raw=asset)
+                self._emit_asset(selector=selector, asset=asset)
         except FileNotFoundError as e:
             logger.error("expected asset files are not found: %s", e)
             raise
 
-    def _emit_assets(self):
+    def _emit_assets(self) -> None:
         """Asset injection as done in all new versions."""
         try:
             for raw_asset_path in glob.glob(f"{ASSET_DIR}{RAW_PATTERN}*"):
                 asset_id = raw_asset_path.split("_", 1)[1]
                 asset_selector_path = f"{SELECTOR_PATTERN}{asset_id}"
-                with open(raw_asset_path, "rb") as asset_raw_o, open(
-                    asset_selector_path, "r", encoding="utf-8"
-                ) as asset_selector_o:
+                with (
+                    open(raw_asset_path, "rb") as asset_raw_o,
+                    open(
+                        asset_selector_path, "r", encoding="utf-8"
+                    ) as asset_selector_o,
+                ):
                     asset = asset_raw_o.read()
                     selector = asset_selector_o.read()
-                    logger.info(
-                        "injecting asset of size %d to selector %s",
-                        len(asset),
-                        selector,
-                    )
-                    self.emit_raw(selector=selector, raw=asset)
+                    self._emit_asset(selector=selector, asset=asset)
         except FileNotFoundError as e:
             logger.error("expected asset files are not found: %s", e)
             raise
+
+    def _emit_asset(self, selector: str, asset: bytes) -> None:
+        """Emit a single asset, checking out repository assets beforehand."""
+        selector = selector.strip()
+        if selector == REPOSITORY_SELECTOR:
+            try:
+                self._checkout_repository(asset)
+            except provider_errors.CloneError as e:
+                logger.error("skipping repository asset: %s", e)
+                return
+
+        logger.info("injecting asset of size %d to selector %s", len(asset), selector)
+        self.emit_raw(selector=selector, raw=asset)
+
+    def _checkout_repository(self, asset: bytes) -> None:
+        """Clone the repository asset onto the shared scan volume.
+
+        Raises `CloneError` (or a subclass) when the repository cannot be
+        checked out.
+        """
+        repository_message = agent_message.Message.from_raw(REPOSITORY_SELECTOR, asset)
+        ref = base.RepositoryCheckoutRequest(
+            repository_url=repository_message.data.get("repository_url", ""),
+            commit_hash=repository_message.data.get("commit_hash", ""),
+        )
+        if ref.repository_url == "" or ref.commit_hash == "":
+            raise provider_errors.CloneError(
+                "repository asset is missing repository_url or commit_hash"
+            )
+        cloner = registry.cloner_for_url(ref.repository_url)
+        cloner.clone(ref, SHARED_VOLUME_DIR)
+        logger.info("checked out %s into %s", ref.repository_url, SHARED_VOLUME_DIR)
 
 
 if __name__ == "__main__":

--- a/agent/providers/__init__.py
+++ b/agent/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Pluggable repository provider implementations for the inject asset agent."""

--- a/agent/providers/base.py
+++ b/agent/providers/base.py
@@ -1,0 +1,35 @@
+"""Base contract every repository provider implementation must satisfy."""
+
+import abc
+import dataclasses
+
+
+@dataclasses.dataclass
+class RepositoryCheckoutRequest:
+    """A repository checkout request parsed from a `v3.asset.repository` asset."""
+
+    repository_url: str
+    commit_hash: str
+
+
+class RepositoryCloner(abc.ABC):
+    """Contract for repository checkout providers."""
+
+    @abc.abstractmethod
+    def ensure_credentials(self) -> None:
+        """Load and validate this provider's credentials.
+
+        Invoked by `clone()` only for a private repository. Raises
+        `MissingCredentialsError` when authentication is required but no
+        credentials are configured.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def clone(self, ref: RepositoryCheckoutRequest, destination: str) -> None:
+        """Check out `ref` into `destination`, detecting public vs private.
+
+        A public repository is cloned anonymously; a private one falls back to
+        authenticated cloning. Raises `CloneError` on any failure.
+        """
+        raise NotImplementedError

--- a/agent/providers/bitbucket.py
+++ b/agent/providers/bitbucket.py
@@ -1,0 +1,33 @@
+"""Bitbucket repository provider."""
+
+import logging
+
+from . import base
+from . import errors
+from . import git
+
+logger = logging.getLogger(__name__)
+
+
+class BitbucketCloner(base.RepositoryCloner):
+    """Checks out Bitbucket-hosted repositories onto the shared scan volume.
+
+    A public repository is cloned anonymously. Authenticated cloning of private
+    repositories is finalised when this provider is built out — see
+    REPOSITORY_PROVIDER_DESIGN.md.
+    """
+
+    def ensure_credentials(self) -> None:
+        # TODO(amat-osto): validate Bitbucket credentials once the agent args are defined.
+        return None
+
+    def clone(self, ref: base.RepositoryCheckoutRequest, destination: str) -> None:
+        if git.is_public_repository(ref.repository_url) is True:
+            logger.info("cloning public repository %s", ref.repository_url)
+            git.clone_repository(ref.repository_url, ref.commit_hash, destination)
+            return
+
+        self.ensure_credentials()
+        raise errors.CloneError(
+            "Bitbucket authenticated cloning is not yet implemented"
+        )

--- a/agent/providers/errors.py
+++ b/agent/providers/errors.py
@@ -1,0 +1,17 @@
+"""Exceptions raised by the repository providers.
+
+All provider failures surface as `CloneError` (or a subclass) so the agent core
+catches a single type regardless of forge.
+"""
+
+
+class CloneError(Exception):
+    """Raised when a repository cannot be checked out onto the shared volume."""
+
+
+class MissingCredentialsError(CloneError):
+    """Raised when a provider is missing the credentials it needs to clone."""
+
+
+class UnsupportedProviderError(CloneError):
+    """Raised when no provider matches a repository URL."""

--- a/agent/providers/git.py
+++ b/agent/providers/git.py
@@ -1,0 +1,81 @@
+"""Git operations shared by the repository providers.
+
+These wrappers run `git` non-interactively: a private repository fails fast
+instead of blocking on a credentials prompt.
+"""
+
+import logging
+import os
+import subprocess
+
+from . import errors
+
+logger = logging.getLogger(__name__)
+
+_LS_REMOTE_TIMEOUT_SECONDS = 60
+_CLONE_TIMEOUT_SECONDS = 600
+
+
+def _non_interactive_env() -> dict[str, str]:
+    """Return an environment that makes git fail instead of prompting."""
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = "true"
+    return env
+
+
+def is_public_repository(repository_url: str) -> bool:
+    """Return whether `repository_url` is reachable without authentication.
+
+    Probes with `git ls-remote` — a cheap network call that lists refs without
+    a checkout.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", repository_url, "HEAD"],
+            capture_output=True,
+            timeout=_LS_REMOTE_TIMEOUT_SECONDS,
+            env=_non_interactive_env(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning("git ls-remote failed for %s: %s", repository_url, e)
+        return False
+
+    return result.returncode == 0
+
+
+def clone_repository(
+    repository_url: str, commit_hash: str, destination: str
+) -> None:
+    """Clone `repository_url` into `destination` and check out `commit_hash`.
+
+    Raises `CloneError` when the clone or the checkout fails.
+    """
+    _run_git(
+        ["clone", repository_url, destination],
+        error=f"failed to clone {repository_url}",
+    )
+    _run_git(
+        ["-C", destination, "checkout", commit_hash],
+        error=f"failed to check out {commit_hash}",
+    )
+
+
+def _run_git(args: list[str], error: str) -> None:
+    """Run a git command, raising `CloneError` on a non-zero exit."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            timeout=_CLONE_TIMEOUT_SECONDS,
+            env=_non_interactive_env(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        raise errors.CloneError(f"{error}: {e}") from e
+
+    if result.returncode != 0:
+        raise errors.CloneError(
+            f"{error}: {result.stderr.decode(errors='replace').strip()}"
+        )

--- a/agent/providers/git.py
+++ b/agent/providers/git.py
@@ -45,9 +45,7 @@ def is_public_repository(repository_url: str) -> bool:
     return result.returncode == 0
 
 
-def clone_repository(
-    repository_url: str, commit_hash: str, destination: str
-) -> None:
+def clone_repository(repository_url: str, commit_hash: str, destination: str) -> None:
     """Clone `repository_url` into `destination` and check out `commit_hash`.
 
     Raises `CloneError` when the clone or the checkout fails.

--- a/agent/providers/github.py
+++ b/agent/providers/github.py
@@ -1,0 +1,33 @@
+"""GitHub repository provider."""
+
+import logging
+
+from . import base
+from . import errors
+from . import git
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubCloner(base.RepositoryCloner):
+    """Checks out GitHub-hosted repositories onto the shared scan volume.
+
+    A public repository is cloned anonymously. Authenticated cloning of private
+    repositories is finalised when this provider is built out — see
+    REPOSITORY_PROVIDER_DESIGN.md.
+    """
+
+    def ensure_credentials(self) -> None:
+        # TODO(amat-osto): validate GitHub credentials once the agent args are defined.
+        return None
+
+    def clone(self, ref: base.RepositoryCheckoutRequest, destination: str) -> None:
+        if git.is_public_repository(ref.repository_url) is True:
+            logger.info("cloning public repository %s", ref.repository_url)
+            git.clone_repository(ref.repository_url, ref.commit_hash, destination)
+            return
+
+        self.ensure_credentials()
+        raise errors.CloneError(
+            "GitHub authenticated cloning is not yet implemented"
+        )

--- a/agent/providers/github.py
+++ b/agent/providers/github.py
@@ -28,6 +28,4 @@ class GitHubCloner(base.RepositoryCloner):
             return
 
         self.ensure_credentials()
-        raise errors.CloneError(
-            "GitHub authenticated cloning is not yet implemented"
-        )
+        raise errors.CloneError("GitHub authenticated cloning is not yet implemented")

--- a/agent/providers/gitlab.py
+++ b/agent/providers/gitlab.py
@@ -28,6 +28,4 @@ class GitLabCloner(base.RepositoryCloner):
             return
 
         self.ensure_credentials()
-        raise errors.CloneError(
-            "GitLab authenticated cloning is not yet implemented"
-        )
+        raise errors.CloneError("GitLab authenticated cloning is not yet implemented")

--- a/agent/providers/gitlab.py
+++ b/agent/providers/gitlab.py
@@ -1,0 +1,33 @@
+"""GitLab repository provider."""
+
+import logging
+
+from . import base
+from . import errors
+from . import git
+
+logger = logging.getLogger(__name__)
+
+
+class GitLabCloner(base.RepositoryCloner):
+    """Checks out GitLab-hosted repositories onto the shared scan volume.
+
+    A public repository is cloned anonymously. Authenticated cloning of private
+    repositories is finalised when this provider is built out — see
+    REPOSITORY_PROVIDER_DESIGN.md.
+    """
+
+    def ensure_credentials(self) -> None:
+        # TODO(amat-osto): validate GitLab credentials once the agent args are defined.
+        return None
+
+    def clone(self, ref: base.RepositoryCheckoutRequest, destination: str) -> None:
+        if git.is_public_repository(ref.repository_url) is True:
+            logger.info("cloning public repository %s", ref.repository_url)
+            git.clone_repository(ref.repository_url, ref.commit_hash, destination)
+            return
+
+        self.ensure_credentials()
+        raise errors.CloneError(
+            "GitLab authenticated cloning is not yet implemented"
+        )

--- a/agent/providers/registry.py
+++ b/agent/providers/registry.py
@@ -1,0 +1,33 @@
+"""Maps a repository URL to the forge provider that owns it.
+
+Host-to-provider matching lives only here; the providers themselves are
+unaware of how they are selected.
+"""
+
+import urllib.parse
+
+from . import base
+from . import bitbucket
+from . import errors
+from . import github
+from . import gitlab
+
+_PROVIDERS_BY_HOST: dict[str, type[base.RepositoryCloner]] = {
+    "github.com": github.GitHubCloner,
+    "gitlab.com": gitlab.GitLabCloner,
+    "bitbucket.org": bitbucket.BitbucketCloner,
+}
+
+
+def cloner_for_url(repository_url: str) -> base.RepositoryCloner:
+    """Return a repository cloner for `repository_url`, matched by host.
+
+    Raises `UnsupportedProviderError` when no provider matches the host.
+    """
+    host = urllib.parse.urlparse(repository_url).hostname
+    provider_class = _PROVIDERS_BY_HOST.get((host or "").lower())
+    if provider_class is None:
+        raise errors.UnsupportedProviderError(
+            f"no repository provider for URL: {repository_url}"
+        )
+    return provider_class()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest bootstrap.
+
+Put the `agent/` directory on `sys.path` so tests import `agent` and
+`providers` exactly as they resolve at runtime (`python /app/agent/agent.py`).
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "agent"))

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -40,6 +40,12 @@ out_selectors:
   - v3.asset.store.ios_store
   - v3.asset.store.ios_testflight
   - v3.asset.file.api_schema
+  - v3.asset.repository
+
+volumes:
+  - name: repository_code
+    path: /code
+    read_only: false
 docker_file_path : Dockerfile # Dockerfile path for automated release build.
 docker_build_root : . # Docker build dir for automated release build.
 supported_architectures:

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1,23 +1,56 @@
 """Unittests for inject asset agent."""
 
+from pathlib import Path
+
+import pytest
+import pyfakefs.fake_filesystem
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.agent.message import message
+from ostorlab.agent.message import serializer
 from ostorlab.runtimes import definitions as runtime_definitions
 
-from agent import agent
+import agent
+from providers import git
+
+_REAL_MESSAGE_CODE_PATH = Path(serializer.__file__).resolve().parent / "proto"
+_FAKE_MESSAGE_CODE_PATH = "/tmp/ostorlab/agent/message/proto"
+
+APK_MESSAGE_RAW = message.Message.from_data(
+    selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
+).raw
+REPOSITORY_MESSAGE_RAW = message.Message.from_data(
+    selector="v3.asset.repository",
+    data={
+        "repository_url": "https://github.com/owner/repo",
+        "commit_hash": "abc123",
+    },
+).raw
 
 
-def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(agent_mock, fs):
+def _add_real_ostorlab_message_protos(
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expose the real ostorlab message proto tree to pyfakefs."""
+    monkeypatch.setattr(serializer, "MESSAGE_CODE_PATH", _FAKE_MESSAGE_CODE_PATH)
+    fs.add_real_directory(
+        str(_REAL_MESSAGE_CODE_PATH), target_path=_FAKE_MESSAGE_CODE_PATH
+    )
+
+
+def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensures file is injected using the provided selector."""
     # The pymockfs overrides the whole filesystem, which causes the message serialization to fail as it is looking for
     # proto files. This adds a passthrough to the real filesystem.
     fs.add_real_directory("/home/")
     fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    msg = message.Message.from_data(
-        selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
-    )
-    fs.create_file(file_path="/asset/asset.binproto_1", contents=msg.raw)
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path="/asset/selector.txt_1", contents="v3.asset.file.android.apk"
     )
@@ -33,24 +66,26 @@ def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(agent_mock
     test_agent.start()
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
-    assert agent_mock[0].raw == msg.raw
+    assert agent_mock[0].raw == APK_MESSAGE_RAW
 
 
-def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(agent_mock, fs):
+def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensures file is injected using the provided selector."""
     # The pymockfs overrides the whole filesystem, which causes the message serialization to fail as it is looking for
     # proto files. This adds a passthrough to the real filesystem.
     fs.add_real_directory("/home/")
     fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    msg = message.Message.from_data(
-        selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
-    )
-    fs.create_file(file_path="/asset/asset.binproto_1", contents=msg.raw)
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path="/asset/selector.txt_1", contents="v3.asset.file.android.apk"
     )
-    fs.create_file(file_path="/asset/asset.binproto_2", contents=msg.raw)
+    fs.create_file(file_path="/asset/asset.binproto_2", contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path="/asset/selector.txt_2", contents="v3.asset.file.android.apk"
     )
@@ -66,22 +101,24 @@ def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(agent_mock, fs):
     test_agent.start()
     assert len(agent_mock) == 2
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
-    assert agent_mock[0].raw == msg.raw
+    assert agent_mock[0].raw == APK_MESSAGE_RAW
     assert agent_mock[1].selector == "v3.asset.file.android.apk"
-    assert agent_mock[1].raw == msg.raw
+    assert agent_mock[1].raw == APK_MESSAGE_RAW
 
 
-def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(agent_mock, fs):
+def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensures file is injected using the provided selector."""
     # The pymockfs overrides the whole filesystem, which causes the message serialization to fail as it is lookgin for
     # proto files. This add a passthrough to the real filesystem.
     fs.add_real_directory("/home/")
     fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    msg = message.Message.from_data(
-        selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
-    )
-    fs.create_file(file_path=agent.ASSET_RAW_PATH, contents=msg.raw)
+    fs.create_file(file_path=agent.ASSET_RAW_PATH, contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path=agent.ASSET_SELECTOR_PATH, contents="v3.asset.file.android.apk"
     )
@@ -97,4 +134,65 @@ def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(agent_mock,
     test_agent.run()
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
-    assert agent_mock[0].raw == msg.raw
+    assert agent_mock[0].raw == APK_MESSAGE_RAW
+
+
+def testInjectAssetAgent_whenRepositoryAssetIsPrivateAndCannotBeCloned_repositoryAssetIsSkipped(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensures a private repository asset is not emitted when the checkout fails."""
+    fs.add_real_directory("/home/")
+    fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
+    monkeypatch.setattr(git, "is_public_repository", lambda repository_url: False)
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=REPOSITORY_MESSAGE_RAW)
+    fs.create_file(file_path="/asset/selector.txt_1", contents="v3.asset.repository")
+    definition = agent_definitions.AgentDefinition(
+        name="start_test_agent", out_selectors=["v3.asset.repository"]
+    )
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/agent_inject_asset"
+    )
+    test_agent = agent.AgentInjectAsset(definition, settings)
+
+    test_agent.start()
+
+    assert len(agent_mock) == 0
+
+
+def testInjectAssetAgent_whenRepositoryAssetIsPublic_repositoryAssetIsInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensures a public repository asset is cloned and then emitted."""
+    fs.add_real_directory("/home/")
+    fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
+    clone_calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(git, "is_public_repository", lambda repository_url: True)
+    monkeypatch.setattr(
+        git,
+        "clone_repository",
+        lambda repository_url, commit_hash, destination: clone_calls.append(
+            (repository_url, commit_hash, destination)
+        ),
+    )
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=REPOSITORY_MESSAGE_RAW)
+    fs.create_file(file_path="/asset/selector.txt_1", contents="v3.asset.repository")
+    definition = agent_definitions.AgentDefinition(
+        name="start_test_agent", out_selectors=["v3.asset.repository"]
+    )
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/agent_inject_asset"
+    )
+    test_agent = agent.AgentInjectAsset(definition, settings)
+
+    test_agent.start()
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.asset.repository"
+    assert agent_mock[0].raw == REPOSITORY_MESSAGE_RAW
+    assert clone_calls == [("https://github.com/owner/repo", "abc123", "/code")]

--- a/tests/providers/git_test.py
+++ b/tests/providers/git_test.py
@@ -1,0 +1,52 @@
+"""Unittests for the git helper."""
+
+import subprocess
+
+import pytest
+
+from providers import errors
+from providers import git
+
+
+def testIsPublicRepository_whenLsRemoteSucceeds_returnsTrue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repository reachable without authentication reports as public."""
+    monkeypatch.setattr(
+        git.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, b"", b""),
+    )
+
+    is_public = git.is_public_repository("https://github.com/owner/repo")
+
+    assert is_public is True
+
+
+def testIsPublicRepository_whenLsRemoteFails_returnsFalse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repository that needs authentication reports as not public."""
+    monkeypatch.setattr(
+        git.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 128, b"", b"denied"),
+    )
+
+    is_public = git.is_public_repository("https://github.com/owner/repo")
+
+    assert is_public is False
+
+
+def testCloneRepository_whenGitExitsNonZero_raisesCloneError(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing git command surfaces as a CloneError."""
+    monkeypatch.setattr(
+        git.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 128, b"", b"boom"),
+    )
+
+    with pytest.raises(errors.CloneError):
+        git.clone_repository("https://github.com/owner/repo", "abc123", "/code")

--- a/tests/providers/github_test.py
+++ b/tests/providers/github_test.py
@@ -1,0 +1,41 @@
+"""Unittests for the GitHub repository provider."""
+
+import pytest
+
+from providers import base
+from providers import errors
+from providers import git
+from providers import github
+
+
+def testClone_whenRepositoryIsPublic_clonesAnonymously(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A public repository is cloned without credentials."""
+    clone_calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(git, "is_public_repository", lambda repository_url: True)
+    monkeypatch.setattr(
+        git,
+        "clone_repository",
+        lambda repository_url, commit_hash, destination: clone_calls.append(
+            (repository_url, commit_hash, destination)
+        ),
+    )
+    cloner = github.GitHubCloner()
+    ref = base.RepositoryCheckoutRequest("https://github.com/owner/repo", "abc123")
+
+    cloner.clone(ref, "/code")
+
+    assert clone_calls == [("https://github.com/owner/repo", "abc123", "/code")]
+
+
+def testClone_whenRepositoryIsPrivate_raisesCloneError(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A private repository raises until authenticated cloning is implemented."""
+    monkeypatch.setattr(git, "is_public_repository", lambda repository_url: False)
+    cloner = github.GitHubCloner()
+    ref = base.RepositoryCheckoutRequest("https://github.com/owner/repo", "abc123")
+
+    with pytest.raises(errors.CloneError):
+        cloner.clone(ref, "/code")

--- a/tests/providers/registry_test.py
+++ b/tests/providers/registry_test.py
@@ -1,0 +1,36 @@
+"""Unittests for the repository provider registry."""
+
+import pytest
+
+from providers import bitbucket
+from providers import errors
+from providers import github
+from providers import gitlab
+from providers import registry
+
+
+def testClonerForUrl_whenGitHubUrl_returnsGitHubCloner() -> None:
+    """A github.com URL resolves to the GitHub provider."""
+    cloner = registry.cloner_for_url("https://github.com/owner/repo")
+
+    assert isinstance(cloner, github.GitHubCloner)
+
+
+def testClonerForUrl_whenGitLabUrl_returnsGitLabCloner() -> None:
+    """A gitlab.com URL resolves to the GitLab provider."""
+    cloner = registry.cloner_for_url("https://gitlab.com/owner/repo")
+
+    assert isinstance(cloner, gitlab.GitLabCloner)
+
+
+def testClonerForUrl_whenBitbucketUrl_returnsBitbucketCloner() -> None:
+    """A bitbucket.org URL resolves to the Bitbucket provider."""
+    cloner = registry.cloner_for_url("https://bitbucket.org/owner/repo")
+
+    assert isinstance(cloner, bitbucket.BitbucketCloner)
+
+
+def testClonerForUrl_whenUnknownHost_raisesUnsupportedProviderError() -> None:
+    """A URL whose host matches no provider raises an error."""
+    with pytest.raises(errors.UnsupportedProviderError):
+        registry.cloner_for_url("https://example.com/owner/repo")


### PR DESCRIPTION
## Summary

Adds support for the `v3.asset.repository` asset to `inject_asset`. When a
repository asset is injected, the agent checks out the source code onto the
shared scan volume (`/code`) **before** emitting the message, so downstream
agents always find real code on disk. The message on the bus carries only
metadata (`repository_url`, `commit_hash`).

## Design

A small pluggable architecture so each forge owns its own logic:

- **`providers/base.py`** — `RepositoryCloner` contract + `RepositoryCheckoutRequest`.
- **`providers/registry.py`** — maps a repository URL to a provider by host.
- **`providers/github.py` / `gitlab.py` / `bitbucket.py`** — per-forge implementations.
- **`providers/git.py`** — shared git helper: `ls-remote` probe + `clone` + `checkout`.
- **`providers/errors.py`** — `CloneError`, `MissingCredentialsError`, `UnsupportedProviderError`.

### Public vs. private

The proto carries no public/private flag, so `clone()` detects it:

1. `git ls-remote` the URL anonymously (cheap probe, no checkout).
2. reachable → clone anonymously.
3. not reachable → `ensure_credentials()` → authenticated clone.

Public repositories work today. Authenticated cloning of private repositories
is the remaining per-provider work (credential wiring).

## Changes

- `ostorlab.yaml` — declares the `v3.asset.repository` selector and the
  `repository_code` shared volume.
- `Dockerfile` — installs `git` for the clone helper.
- `agent.py` — routes the repository selector through provider selection +
  clone; rejects assets with an empty `repository_url` / `commit_hash`; a
  failed checkout skips the asset instead of emitting a message with no code.

## Verification

Built the agent and ran a scan against a public repository
(`https://github.com/Ostorlab/oxo` @ `1962b661d166436b1418ee225bcb48c26e47bbbf`):

```
🔹 agent_ostorlab_inject_asset_18_9163: [11:02:38] INFO  cloning public repository       github.py:26
🔹 agent_ostorlab_inject_asset_18_9163:                  https://github.com/Ostorlab/oxo
🔹 agent_ostorlab_inject_asset_18_9163: [11:02:56] INFO  checked out https://github.com/Ostorlab/oxo  agent.py:107
🔹 agent_ostorlab_inject_asset_18_9163:                  into /code
🔹 agent_ostorlab_inject_asset_18_9163:           INFO  injecting asset of size 75 to selector  agent.py:87
🔹 agent_ostorlab_inject_asset_18_9163:                  v3.asset.repository
```

The probe detected a public repo, the code was cloned and checked out into
`/code`, and the `v3.asset.repository` message was emitted **only after** the
checkout finished — the required ordering.

## Tests

`pytest` — 14 passing: agent injection (public cloned + emitted, private
skipped), registry host matching, provider public/private branching, and the
git helper. All git calls are mocked, so no network access in CI.