### PR TITLE
feature: repository checkout plumbing (1/3)

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Inject asset agent package."""

--- a/agent/providers/__init__.py
+++ b/agent/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Pluggable repository provider implementations for the inject asset agent."""

--- a/agent/providers/base.py
+++ b/agent/providers/base.py
@@ -1,0 +1,35 @@
+"""Base contract every repository provider implementation must satisfy."""
+
+import abc
+import dataclasses
+
+
+@dataclasses.dataclass
+class RepositoryCheckoutRequest:
+    """A repository checkout request parsed from a `v3.asset.repository` asset."""
+
+    repository_url: str
+    commit_hash: str
+
+
+class RepositoryCloner(abc.ABC):
+    """Contract for repository checkout providers."""
+
+    @abc.abstractmethod
+    def ensure_credentials(self) -> None:
+        """Load and validate this provider's credentials.
+
+        Invoked by `clone()` only for a private repository. Raises
+        `MissingCredentialsError` when authentication is required but no
+        credentials are configured.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def clone(self, ref: RepositoryCheckoutRequest, destination: str) -> None:
+        """Check out `ref` into `destination`, detecting public vs private.
+
+        A public repository is cloned anonymously; a private one falls back to
+        authenticated cloning. Raises `CloneError` on any failure.
+        """
+        raise NotImplementedError

--- a/agent/providers/errors.py
+++ b/agent/providers/errors.py
@@ -1,0 +1,17 @@
+"""Exceptions raised by the repository providers.
+
+All provider failures surface as `CloneError` (or a subclass) so the agent core
+catches a single type regardless of forge.
+"""
+
+
+class CloneError(Exception):
+    """Raised when a repository cannot be checked out onto the shared volume."""
+
+
+class MissingCredentialsError(CloneError):
+    """Raised when a provider is missing the credentials it needs to clone."""
+
+
+class UnsupportedProviderError(CloneError):
+    """Raised when no provider matches a repository URL."""

--- a/agent/providers/git.py
+++ b/agent/providers/git.py
@@ -1,0 +1,79 @@
+"""Git operations shared by the repository providers.
+
+These wrappers run `git` non-interactively: a private repository fails fast
+instead of blocking on a credentials prompt.
+"""
+
+import logging
+import os
+import subprocess
+
+from . import errors
+
+logger = logging.getLogger(__name__)
+
+_LS_REMOTE_TIMEOUT_SECONDS = 60
+_CLONE_TIMEOUT_SECONDS = 600
+
+
+def _non_interactive_env() -> dict[str, str]:
+    """Return an environment that makes git fail instead of prompting."""
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = "true"
+    return env
+
+
+def is_public_repository(repository_url: str) -> bool:
+    """Return whether `repository_url` is reachable without authentication.
+
+    Probes with `git ls-remote` — a cheap network call that lists refs without
+    a checkout.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", repository_url, "HEAD"],
+            capture_output=True,
+            timeout=_LS_REMOTE_TIMEOUT_SECONDS,
+            env=_non_interactive_env(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning("git ls-remote failed for %s: %s", repository_url, e)
+        return False
+
+    return result.returncode == 0
+
+
+def clone_repository(repository_url: str, commit_hash: str, destination: str) -> None:
+    """Clone `repository_url` into `destination` and check out `commit_hash`.
+
+    Raises `CloneError` when the clone or the checkout fails.
+    """
+    _run_git(
+        ["clone", repository_url, destination],
+        error=f"failed to clone {repository_url}",
+    )
+    _run_git(
+        ["-C", destination, "checkout", commit_hash],
+        error=f"failed to check out {commit_hash}",
+    )
+
+
+def _run_git(args: list[str], error: str) -> None:
+    """Run a git command, raising `CloneError` on a non-zero exit."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            timeout=_CLONE_TIMEOUT_SECONDS,
+            env=_non_interactive_env(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        raise errors.CloneError(f"{error}: {e}") from e
+
+    if result.returncode != 0:
+        raise errors.CloneError(
+            f"{error}: {result.stderr.decode(errors='replace').strip()}"
+        )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-# Put agent/ on sys.path so tests import agent and providers exactly as
-# they resolve at runtime (python /app/agent/agent.py).
-pythonpath = agent

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Put agent/ on sys.path so tests import agent and providers exactly as
+# they resolve at runtime (python /app/agent/agent.py).
+pythonpath = agent

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1,23 +1,48 @@
 """Unittests for inject asset agent."""
 
+from pathlib import Path
+
+import pytest
+import pyfakefs.fake_filesystem
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.agent.message import message
+from ostorlab.agent.message import serializer
 from ostorlab.runtimes import definitions as runtime_definitions
 
-from agent import agent
+import agent
+
+_REAL_MESSAGE_CODE_PATH = Path(serializer.__file__).resolve().parent / "proto"
+_FAKE_MESSAGE_CODE_PATH = "/tmp/ostorlab/agent/message/proto"
+
+APK_MESSAGE_RAW = message.Message.from_data(
+    selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
+).raw
 
 
-def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(agent_mock, fs):
+def _add_real_ostorlab_message_protos(
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expose the real ostorlab message proto tree to pyfakefs."""
+    monkeypatch.setattr(serializer, "MESSAGE_CODE_PATH", _FAKE_MESSAGE_CODE_PATH)
+    fs.add_real_directory(
+        str(_REAL_MESSAGE_CODE_PATH), target_path=_FAKE_MESSAGE_CODE_PATH
+    )
+
+
+def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensures file is injected using the provided selector."""
     # The pymockfs overrides the whole filesystem, which causes the message serialization to fail as it is looking for
     # proto files. This adds a passthrough to the real filesystem.
     fs.add_real_directory("/home/")
     fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    msg = message.Message.from_data(
-        selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
-    )
-    fs.create_file(file_path="/asset/asset.binproto_1", contents=msg.raw)
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path="/asset/selector.txt_1", contents="v3.asset.file.android.apk"
     )
@@ -33,24 +58,26 @@ def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(agent_mock
     test_agent.start()
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
-    assert agent_mock[0].raw == msg.raw
+    assert agent_mock[0].raw == APK_MESSAGE_RAW
 
 
-def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(agent_mock, fs):
+def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensures file is injected using the provided selector."""
     # The pymockfs overrides the whole filesystem, which causes the message serialization to fail as it is looking for
     # proto files. This adds a passthrough to the real filesystem.
     fs.add_real_directory("/home/")
     fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    msg = message.Message.from_data(
-        selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
-    )
-    fs.create_file(file_path="/asset/asset.binproto_1", contents=msg.raw)
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path="/asset/selector.txt_1", contents="v3.asset.file.android.apk"
     )
-    fs.create_file(file_path="/asset/asset.binproto_2", contents=msg.raw)
+    fs.create_file(file_path="/asset/asset.binproto_2", contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path="/asset/selector.txt_2", contents="v3.asset.file.android.apk"
     )
@@ -66,22 +93,24 @@ def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(agent_mock, fs):
     test_agent.start()
     assert len(agent_mock) == 2
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
-    assert agent_mock[0].raw == msg.raw
+    assert agent_mock[0].raw == APK_MESSAGE_RAW
     assert agent_mock[1].selector == "v3.asset.file.android.apk"
-    assert agent_mock[1].raw == msg.raw
+    assert agent_mock[1].raw == APK_MESSAGE_RAW
 
 
-def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(agent_mock, fs):
+def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensures file is injected using the provided selector."""
     # The pymockfs overrides the whole filesystem, which causes the message serialization to fail as it is lookgin for
     # proto files. This add a passthrough to the real filesystem.
     fs.add_real_directory("/home/")
     fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    msg = message.Message.from_data(
-        selector="v3.asset.file.android.apk", data={"content": b"FAKE"}
-    )
-    fs.create_file(file_path=agent.ASSET_RAW_PATH, contents=msg.raw)
+    fs.create_file(file_path=agent.ASSET_RAW_PATH, contents=APK_MESSAGE_RAW)
     fs.create_file(
         file_path=agent.ASSET_SELECTOR_PATH, contents="v3.asset.file.android.apk"
     )
@@ -97,4 +126,4 @@ def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(agent_mock,
     test_agent.run()
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
-    assert agent_mock[0].raw == msg.raw
+    assert agent_mock[0].raw == APK_MESSAGE_RAW

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -9,7 +9,7 @@ from ostorlab.agent.message import message
 from ostorlab.agent.message import serializer
 from ostorlab.runtimes import definitions as runtime_definitions
 
-import agent
+from agent import agent as agent_module
 
 _REAL_MESSAGE_CODE_PATH = pathlib.Path(serializer.__file__).resolve().parent / "proto"
 _FAKE_MESSAGE_CODE_PATH = "/tmp/ostorlab/agent/message/proto"
@@ -54,7 +54,7 @@ def testInjectAssetAgent_whenExpectFilesArePresent_rawAssetIsInjected(
         key="agent/ostorlab/agent_inject_asset"
     )
 
-    test_agent = agent.AgentInjectAsset(definition, settings)
+    test_agent = agent_module.AgentInjectAsset(definition, settings)
     test_agent.start()
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
@@ -89,7 +89,7 @@ def testInjectAssetAgent_withMultipleAsset_rawAssetAreInjected(
         key="agent/ostorlab/agent_inject_asset"
     )
 
-    test_agent = agent.AgentInjectAsset(definition, settings)
+    test_agent = agent_module.AgentInjectAsset(definition, settings)
     test_agent.start()
     assert len(agent_mock) == 2
     assert agent_mock[0].selector == "v3.asset.file.android.apk"
@@ -110,9 +110,10 @@ def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(
     fs.add_real_directory("/opt/")
     _add_real_ostorlab_message_protos(fs, monkeypatch)
 
-    fs.create_file(file_path=agent.ASSET_RAW_PATH, contents=APK_MESSAGE_RAW)
+    fs.create_file(file_path=agent_module.ASSET_RAW_PATH, contents=APK_MESSAGE_RAW)
     fs.create_file(
-        file_path=agent.ASSET_SELECTOR_PATH, contents="v3.asset.file.android.apk"
+        file_path=agent_module.ASSET_SELECTOR_PATH,
+        contents="v3.asset.file.android.apk",
     )
 
     definition = agent_definitions.AgentDefinition(
@@ -122,7 +123,7 @@ def testInjectAssetAgent_whenLegacyAssetInjection_rawAssetIsInjected(
         key="agent/ostorlab/agent_inject_asset"
     )
 
-    test_agent = agent.AgentInjectAsset(definition, settings)
+    test_agent = agent_module.AgentInjectAsset(definition, settings)
     test_agent.run()
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.asset.file.android.apk"

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1,6 +1,6 @@
 """Unittests for inject asset agent."""
 
-from pathlib import Path
+import pathlib
 
 import pytest
 import pyfakefs.fake_filesystem
@@ -11,7 +11,7 @@ from ostorlab.runtimes import definitions as runtime_definitions
 
 import agent
 
-_REAL_MESSAGE_CODE_PATH = Path(serializer.__file__).resolve().parent / "proto"
+_REAL_MESSAGE_CODE_PATH = pathlib.Path(serializer.__file__).resolve().parent / "proto"
 _FAKE_MESSAGE_CODE_PATH = "/tmp/ostorlab/agent/message/proto"
 
 APK_MESSAGE_RAW = message.Message.from_data(

--- a/tests/providers/git_test.py
+++ b/tests/providers/git_test.py
@@ -4,8 +4,8 @@ import subprocess
 
 import pytest
 
-from providers import errors
-from providers import git
+from agent.providers import errors
+from agent.providers import git
 
 
 def testIsPublicRepository_whenLsRemoteSucceeds_returnsTrue(

--- a/tests/providers/git_test.py
+++ b/tests/providers/git_test.py
@@ -1,0 +1,52 @@
+"""Unittests for the git helper."""
+
+import subprocess
+
+import pytest
+
+from providers import errors
+from providers import git
+
+
+def testIsPublicRepository_whenLsRemoteSucceeds_returnsTrue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repository reachable without authentication reports as public."""
+    monkeypatch.setattr(
+        git.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, b"", b""),
+    )
+
+    is_public = git.is_public_repository("https://github.com/owner/repo")
+
+    assert is_public is True
+
+
+def testIsPublicRepository_whenLsRemoteFails_returnsFalse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repository that needs authentication reports as not public."""
+    monkeypatch.setattr(
+        git.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 128, b"", b"denied"),
+    )
+
+    is_public = git.is_public_repository("https://github.com/owner/repo")
+
+    assert is_public is False
+
+
+def testCloneRepository_whenGitExitsNonZero_raisesCloneError(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing git command surfaces as a CloneError."""
+    monkeypatch.setattr(
+        git.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 128, b"", b"boom"),
+    )
+
+    with pytest.raises(errors.CloneError):
+        git.clone_repository("https://github.com/owner/repo", "abc123", "/code")


### PR DESCRIPTION
**Stack 1 of 3** — splits #49 into reviewable layers. Targets `main`.

## Summary
Foundation for checking out `v3.asset.repository` assets onto the shared scan volume. No agent behaviour changes yet — this layer is pure plumbing exercised by its own tests.

## Contents
- `providers/base.py` — `RepositoryCloner` contract + `RepositoryCheckoutRequest`
- `providers/errors.py` — `CloneError` hierarchy (`MissingCredentialsError`, `UnsupportedProviderError`)
- `providers/git.py` — non-interactive git helper: `ls-remote` probe, `clone`, `checkout`
- `conftest.py` — puts `agent/` on `sys.path` so tests import `providers` as at runtime; `agent/__init__.py` removed so `import agent` resolves to the module

## Tests
`tests/providers/git_test.py` — 3 passing, all git calls mocked (no network).

## Stack
1. **This PR** → `main`
2. #51 — forge providers + registry
3. #52 — agent integration

Replaces #49 (left open for reference).