### PR TITLE
fix: emit plain file asset alongside a risk's embedded target

### DIFF
--- a/agent/agent_inject_asset.py
+++ b/agent/agent_inject_asset.py
@@ -19,7 +19,16 @@ ASSET_DIR = "/asset/"
 RAW_PATTERN = "asset.binproto_"
 SELECTOR_PATTERN = "/asset/selector.txt_"
 REPOSITORY_SELECTOR = "v3.asset.repository"
+RISK_SELECTOR = "v3.report.risk"
 SHARED_VOLUME_DIR = "/code"
+
+# Risk targets that other agents in the same universe may still expect as a plain file asset,
+# mapped to that asset's own selector.
+_RISK_TARGET_TO_PLAIN_SELECTOR = {
+    "ios_ipa": "v3.asset.file.ios.ipa",
+    "android_apk": "v3.asset.file.android.apk",
+    "android_aab": "v3.asset.file.android.aab",
+}
 
 # Before Ostorlab version 0.3.1 (including).
 ASSET_RAW_PATH = "/tmp/asset.binproto"
@@ -86,9 +95,29 @@ class AgentInjectAsset(agent.Agent):
             except provider_errors.CloneError as e:
                 logger.error("skipping repository asset: %s", e)
                 return
+        elif selector == RISK_SELECTOR:
+            self._emit_plain_asset_from_risk(asset)
 
         logger.info("injecting asset of size %d to selector %s", len(asset), selector)
         self.emit_raw(selector=selector, raw=asset)
+
+    def _emit_plain_asset_from_risk(self, asset: bytes) -> None:
+        """Also emit the risk's embedded file asset under its own plain selector.
+
+        Some universes run agents that consume a risk asset (e.g. auto_exploit) alongside
+        agents that still expect the plain file asset the risk was built from (e.g. file_info).
+        This derives that plain asset from the risk's embedded target and emits it too, without
+        the risk's description/rating, so both kinds of agents get what they need.
+        """
+        risk_message = agent_message.Message.from_raw(RISK_SELECTOR, asset)
+        for target_name, plain_selector in _RISK_TARGET_TO_PLAIN_SELECTOR.items():
+            target_data = risk_message.data.get(target_name)
+            if target_data is not None:
+                plain_message = agent_message.Message.from_data(
+                    plain_selector, target_data
+                )
+                self.emit_raw(selector=plain_message.selector, raw=plain_message.raw)
+                return
 
     def _authenticate_if_needed(
         self, ref: base.RepositoryCheckoutRequest, cloner: base.RepositoryCloner

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -27,6 +27,30 @@ REPOSITORY_MESSAGE_RAW = message.Message.from_data(
         "commit_hash": "abc123",
     },
 ).raw
+IOS_IPA_RISK_MESSAGE_RAW = message.Message.from_data(
+    selector="v3.report.risk",
+    data={
+        "description": "test risk description",
+        "rating": "HIGH",
+        "ios_ipa": {"content_url": "https://example.com/app.ipa"},
+    },
+).raw
+ANDROID_APK_RISK_MESSAGE_RAW = message.Message.from_data(
+    selector="v3.report.risk",
+    data={
+        "description": "test risk description",
+        "rating": "HIGH",
+        "android_apk": {"content_url": "https://example.com/app.apk"},
+    },
+).raw
+LINK_RISK_MESSAGE_RAW = message.Message.from_data(
+    selector="v3.report.risk",
+    data={
+        "description": "test risk description",
+        "rating": "HIGH",
+        "link": {"url": "https://example.com"},
+    },
+).raw
 
 
 def _add_real_ostorlab_message_protos(
@@ -412,3 +436,97 @@ def testInjectAssetAgent_whenRepositoryAssetIsPrivateWithEmbeddedCreds_skipsToke
     assert clone_calls == [
         ("https://user:pass@github.com/owner/repo", "abc123", "/code")
     ]
+
+
+def testInjectAssetAgent_whenRiskHasIosIpaTarget_alsoEmitsPlainIpaAsset(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A risk asset with an embedded ios_ipa target also emits a plain ipa asset."""
+    fs.add_real_directory("/home/")
+    fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
+
+    fs.create_file(
+        file_path="/asset/asset.binproto_1", contents=IOS_IPA_RISK_MESSAGE_RAW
+    )
+    fs.create_file(file_path="/asset/selector.txt_1", contents="v3.report.risk")
+
+    definition = agent_definitions.AgentDefinition(
+        name="start_test_agent",
+        out_selectors=["v3.report.risk", "v3.asset.file.ios.ipa"],
+    )
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/agent_inject_asset"
+    )
+
+    test_agent = agent_module.AgentInjectAsset(definition, settings)
+    test_agent.start()
+
+    assert len(agent_mock) == 2
+    assert agent_mock[0].selector == "v3.asset.file.ios.ipa"
+    assert agent_mock[0].data == {"content_url": "https://example.com/app.ipa"}
+    assert agent_mock[1].selector == "v3.report.risk"
+    assert agent_mock[1].raw == IOS_IPA_RISK_MESSAGE_RAW
+
+
+def testInjectAssetAgent_whenRiskHasAndroidApkTarget_alsoEmitsPlainApkAsset(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A risk asset with an embedded android_apk target also emits a plain apk asset."""
+    fs.add_real_directory("/home/")
+    fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
+
+    fs.create_file(
+        file_path="/asset/asset.binproto_1", contents=ANDROID_APK_RISK_MESSAGE_RAW
+    )
+    fs.create_file(file_path="/asset/selector.txt_1", contents="v3.report.risk")
+
+    definition = agent_definitions.AgentDefinition(
+        name="start_test_agent",
+        out_selectors=["v3.report.risk", "v3.asset.file.android.apk"],
+    )
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/agent_inject_asset"
+    )
+
+    test_agent = agent_module.AgentInjectAsset(definition, settings)
+    test_agent.start()
+
+    assert len(agent_mock) == 2
+    assert agent_mock[0].selector == "v3.asset.file.android.apk"
+    assert agent_mock[0].data == {"content_url": "https://example.com/app.apk"}
+    assert agent_mock[1].selector == "v3.report.risk"
+    assert agent_mock[1].raw == ANDROID_APK_RISK_MESSAGE_RAW
+
+
+def testInjectAssetAgent_whenRiskHasNoKnownFileTarget_onlyEmitsRisk(
+    agent_mock: list[message.Message],
+    fs: pyfakefs.fake_filesystem.FakeFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A risk asset targeting something other than a known file type emits only the risk."""
+    fs.add_real_directory("/home/")
+    fs.add_real_directory("/opt/")
+    _add_real_ostorlab_message_protos(fs, monkeypatch)
+
+    fs.create_file(file_path="/asset/asset.binproto_1", contents=LINK_RISK_MESSAGE_RAW)
+    fs.create_file(file_path="/asset/selector.txt_1", contents="v3.report.risk")
+
+    definition = agent_definitions.AgentDefinition(
+        name="start_test_agent", out_selectors=["v3.report.risk"]
+    )
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/agent_inject_asset"
+    )
+
+    test_agent = agent_module.AgentInjectAsset(definition, settings)
+    test_agent.start()
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.report.risk"
+    assert agent_mock[0].raw == LINK_RISK_MESSAGE_RAW


### PR DESCRIPTION
Shielding store scans now merge shielding, ssl_pinning, and auto_exploit into one universe (see reporting_engine PR #5219), with the downloader publishing a risk asset (embedding the downloaded ipa/apk) since auto_exploit only consumes `v3.report.risk`. The other agents in that same universe (`file_info`, `ios_prepare_dynamic`/`android_prepare_dynamic` in bus mode) still expect the plain file asset (`v3.asset.file.ios.ipa`/`v3.asset.file.android.apk`/`v3.asset.file.android.aab`) though, and previously never got it once the universe's initial asset became a risk.

`_emit_asset` now recognizes the `v3.report.risk` selector, extracts the risk's embedded file target, and additionally emits it under its own plain selector -- on top of emitting the risk message unchanged, as before. This is generic to any universe whose initial asset is a risk with one of these targets, not specific to shielding; universes where nothing subscribes to the plain selector just get one unconsumed extra message.

- `RISK_SELECTOR` / `_RISK_TARGET_TO_PLAIN_SELECTOR`: new constants in `agent/agent_inject_asset.py`, covering the file-asset risk targets actually produced today (`ios_ipa`, `android_apk`, `android_aab`).
- `_emit_plain_asset_from_risk`: parses the risk via `Message.from_raw`, finds whichever of those targets is set, and re-emits it via `Message.from_data` under the plain selector.

**Tests:** `tests/agent_test.py` -- `testInjectAssetAgent_whenRiskHasIosIpaTarget_alsoEmitsPlainIpaAsset` and `_whenRiskHasAndroidApkTarget_...` assert both the derived plain asset and the original risk get emitted; `_whenRiskHasNoKnownFileTarget_onlyEmitsRisk` asserts a risk targeting something else (e.g. a link) emits only the risk, no spurious extra message.