### PR TITLE
feature: Update CODEOWNERS with new readability team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is for defining the code owners for the repository.
 # See https://help.github.com/articles/about-code-owners/ for more information.
-* @Ostorlab/python-readability
+* @Ostorlab/oxo-agent-readability


### PR DESCRIPTION
Updates .github/CODEOWNERS to enforce @Ostorlab/oxo-agent-readability ownership.